### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -32,5 +32,5 @@ To use:
 .. |Build Status| image:: https://travis-ci.org/nose-my-code/nose-my-code.svg?branch=master
     :target: https://travis-ci.org/nose-my-code/nose-my-code
 
-.. |Pypi Status| image:: https://pypip.in/v/restnavigator/badge.png
+.. |Pypi Status| image:: https://img.shields.io/pypi/v/restnavigator.svg
     :target: https://pypi.python.org/pypi/nose-mycode/


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20nose-mycode))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `nose-mycode`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.